### PR TITLE
Fix minor text mistakes

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,7 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                macOS M1
+                Apple Silicon
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-x64.dmg`}
@@ -77,13 +77,13 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                Windows 64bits
+                Windows 64bit
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-ia32-setup.exe`}
-                title="AppImage 32bits"
+                title="AppImage 32bit"
               >
-                32bits
+                32bit
               </ButtonLink>
             </ButtonGroup>
             <ButtonGroup>
@@ -92,13 +92,13 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                Portable 64bits
+                Portable 64bit
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-ia32-portable.exe`}
-                title="AppImage 32bits"
+                title="AppImage 32bit"
               >
-                32bits
+                32bit
               </ButtonLink>
             </ButtonGroup>
           </div>
@@ -112,13 +112,13 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                AppImage 64bits
+                AppImage 64bit
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-i386.AppImage`}
-                title="AppImage 32bits"
+                title="AppImage 32bit"
               >
-                32bits
+                32bit
               </ButtonLink>
             </ButtonGroup>
 
@@ -128,13 +128,13 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                .deb 64bits
+                .deb 64bit
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-i386.deb`}
-                title=".deb 32bits"
+                title=".deb 32bit"
               >
-                32bits
+                32bit
               </ButtonLink>
             </ButtonGroup>
 
@@ -144,13 +144,13 @@ const VERSION = "0.13.1";
                 use="primary"
                 expand
               >
-                .rpm 64bits
+                .rpm 64bit
               </ButtonLink>
               <ButtonLink
                 href={`${URL_PREFIX}${VERSION}/museeks-i686.rpm`}
-                title=".rpm 32bits"
+                title=".rpm 32bit"
               >
-                32bits
+                32bit
               </ButtonLink>
             </ButtonGroup>
           </div>


### PR DESCRIPTION
👋 Hey!

This is branch fixes minor issues with text on the page, such as name of Apple's processor; instead of "macOS m1" to "Apple Silicon". And fixes "bits" to "bit" when referring to a processor, such as 32bit etc.